### PR TITLE
Housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /vendor/
+composer.lock

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ composer require smcrow/laravel-container-info --dev
 ## Register the Command
 
 ### Laravel 5.5
-Laravel 5.5 allows for the auto-discovery of service providers.  The ContainerInformationServiceProvider will automatically be discovered.
+Laravel 5.5 allows for the auto-discovery of service providers.  The ContainerInformationProvider will automatically be discovered.
 
 ### Pre Laravel 5.5
 You'll need to register the command in order for it to be usable.  Modify the `register` method of `AppServiceProvider`  This will add the provider for the local environment:
@@ -27,7 +27,7 @@ You'll need to register the command in order for it to be usable.  Modify the `r
 public function register()
 {
     if ($this->app->environment() === 'local') {
-        $this->app->register(ContainerInformationServiceProvider::class);
+        $this->app->register(ContainerInformationProvider::class);
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   "extra": {
     "laravel": {
       "providers": [
-        "Smcrow\\ContainerInformation\\ContainerInformationServiceProvider"
+        "Smcrow\\ContainerInformation\\ContainerInformationProvider"
       ]
     }
   }

--- a/src/BindingInformation/BindingInformationProvider.php
+++ b/src/BindingInformation/BindingInformationProvider.php
@@ -6,7 +6,7 @@ use Illuminate\Support\ServiceProvider;
 use Smcrow\ContainerInformation\BindingInformation\Commands\ListCommand;
 use Smcrow\ContainerInformation\BindingInformation\Commands\UsageCommand;
 
-class BindingInformationServiceProvider extends ServiceProvider
+class BindingInformationProvider extends ServiceProvider
 {
 
     /**

--- a/src/BindingInformation/Commands/ListCommand.php
+++ b/src/BindingInformation/Commands/ListCommand.php
@@ -20,7 +20,7 @@ class ListCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Show the bound providers on the IoC container.';
+    protected $description = 'Show the bound providers on the IoC container';
 
     /**
      * @var BindingInformation $bindingInformation

--- a/src/BindingInformation/Commands/UsageCommand.php
+++ b/src/BindingInformation/Commands/UsageCommand.php
@@ -20,7 +20,7 @@ class UsageCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Searches the source directory for references to the abstracts that are bound.';
+    protected $description = 'Searches the source directory for references to the abstracts that are bound';
 
     /**
      * @var BindingInformation $bindingInformation

--- a/src/ContainerInformationProvider.php
+++ b/src/ContainerInformationProvider.php
@@ -3,9 +3,9 @@
 namespace Smcrow\ContainerInformation;
 
 use Illuminate\Support\ServiceProvider;
-use Smcrow\ContainerInformation\BindingInformation\BindingInformationServiceProvider;
+use Smcrow\ContainerInformation\BindingInformation\BindingInformationProvider;
 
-class ContainerInformationServiceProvider extends ServiceProvider
+class ContainerInformationProvider extends ServiceProvider
 {
 
     /**
@@ -25,7 +25,7 @@ class ContainerInformationServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->register(BindingInformationServiceProvider::class);
+        $this->app->register(BindingInformationProvider::class);
     }
 
 }


### PR DESCRIPTION
- Removed periods from the command descriptions, for consistency with native Artisan commands
- Removed 'Service' from provider names for conciseness
- Added composer.lock to `.gitignore`