### PR TITLE
Enhance the `provider:list` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This is a suite of custom commands for Artisan that gives information about the 
 
 ## Working with Service Providers
 * `provider:list` - Lists the registered service providers.
+    * `--include-illuminate` - Indicates that Illuminate classes should be included.  They are not included by default.
     * `--sort` - Indicates that the information should be sorted.
 # Usage
 ## Install Through Composer
@@ -65,48 +66,19 @@ php artisan provider:list
 ```
 Here's sample output from a dummy application:
 ```
-+-----------------------------------------------------------------------------+
-| Providers                                                                   |
-+-----------------------------------------------------------------------------+
-| Illuminate\Events\EventServiceProvider                                      |
-| Illuminate\Log\LogServiceProvider                                           |
-| Illuminate\Routing\RoutingServiceProvider                                   |
-| Illuminate\Auth\AuthServiceProvider                                         |
-| Illuminate\Cookie\CookieServiceProvider                                     |
-| Illuminate\Database\DatabaseServiceProvider                                 |
-| Illuminate\Encryption\EncryptionServiceProvider                             |
-| Illuminate\Filesystem\FilesystemServiceProvider                             |
-| Illuminate\Foundation\Providers\FormRequestServiceProvider                  |
-| Illuminate\Foundation\Providers\FoundationServiceProvider                   |
-| Illuminate\Notifications\NotificationServiceProvider                        |
-| Illuminate\Pagination\PaginationServiceProvider                             |
-| Illuminate\Session\SessionServiceProvider                                   |
-| Illuminate\View\ViewServiceProvider                                         |
-| Fideloper\Proxy\TrustedProxyServiceProvider                                 |
-| Smcrow\ContainerInformation\BindingInformation\BindingInformationProvider   |
-| Smcrow\ContainerInformation\ProviderInformation\ProviderInformationProvider |
-| Smcrow\ContainerInformation\ContainerInformationProvider                    |
-| App\Providers\AppServiceProvider                                            |
-| App\Providers\AuthServiceProvider                                           |
-| App\Providers\EventServiceProvider                                          |
-| App\Providers\RouteServiceProvider                                          |
-| Illuminate\Cache\CacheServiceProvider                                       |
-| Illuminate\Broadcasting\BroadcastServiceProvider                            |
-| Illuminate\Bus\BusServiceProvider                                           |
-| Illuminate\Foundation\Providers\ArtisanServiceProvider                      |
-| Illuminate\Database\MigrationServiceProvider                                |
-| Illuminate\Foundation\Providers\ComposerServiceProvider                     |
-| Illuminate\Foundation\Providers\ConsoleSupportServiceProvider               |
-| Illuminate\Hashing\HashServiceProvider                                      |
-| Illuminate\Mail\MailServiceProvider                                         |
-| Illuminate\Pipeline\PipelineServiceProvider                                 |
-| Illuminate\Queue\QueueServiceProvider                                       |
-| Illuminate\Redis\RedisServiceProvider                                       |
-| Illuminate\Auth\Passwords\PasswordResetServiceProvider                      |
-| Illuminate\Translation\TranslationServiceProvider                           |
-| Illuminate\Validation\ValidationServiceProvider                             |
-| Laravel\Tinker\TinkerServiceProvider                                        |
-+-----------------------------------------------------------------------------+
++-----------------------------------------------------------------------------+----------+----------------+
+| Providers                                                                   | Deferred | Provides       |
++-----------------------------------------------------------------------------+----------+----------------+
+| Fideloper\Proxy\TrustedProxyServiceProvider                                 |          |                |
+| Smcrow\ContainerInformation\BindingInformation\BindingInformationProvider   |          |                |
+| Smcrow\ContainerInformation\ProviderInformation\ProviderInformationProvider |          |                |
+| Smcrow\ContainerInformation\ContainerInformationProvider                    |          |                |
+| App\Providers\AppServiceProvider                                            |          |                |
+| App\Providers\AuthServiceProvider                                           |          |                |
+| App\Providers\EventServiceProvider                                          |          |                |
+| App\Providers\RouteServiceProvider                                          |          |                |
+| Laravel\Tinker\TinkerServiceProvider                                        | true     | command.tinker |
++-----------------------------------------------------------------------------+----------+----------------+
 ```
 # Feedback and Contributions
 Please feel free to offer suggestions by submitting an Issue.  Alternatively, submit a pull request with any features you wish to add.  This is a work-in-progress, and I would welcome any and all feedback.

--- a/src/BindingInformation/Commands/ListCommand.php
+++ b/src/BindingInformation/Commands/ListCommand.php
@@ -34,7 +34,7 @@ class ListCommand extends Command
     public function __construct(BindingInformation $bindingInformation)
     {
         parent::__construct();
-        $this->BindingInformation = $bindingInformation;
+        $this->bindingInformation = $bindingInformation;
     }
 
     /**
@@ -45,7 +45,7 @@ class ListCommand extends Command
      */
     public function handle(Container $container)
     {
-        $foundBindings = $this->BindingInformation->getBindingList($this->option('include-illuminate'));
+        $foundBindings = $this->bindingInformation->getBindingList($this->option('include-illuminate'));
 
         $headers = ['Abstract', 'Concrete'];
         $this->table($headers, $foundBindings);

--- a/src/BindingInformation/Commands/UsageCommand.php
+++ b/src/BindingInformation/Commands/UsageCommand.php
@@ -35,7 +35,7 @@ class UsageCommand extends Command
     public function __construct(BindingInformation $bindingInformation)
     {
         parent::__construct();
-        $this->BindingInformation = $bindingInformation;
+        $this->bindingInformation = $bindingInformation;
     }
 
     /**
@@ -46,7 +46,7 @@ class UsageCommand extends Command
      */
     public function handle(Container $container)
     {
-        $usageList = $this->BindingInformation->getUsageList($this->option('include-illuminate'));
+        $usageList = $this->bindingInformation->getUsageList($this->option('include-illuminate'));
         if ($this->option('sort')) {
             ksort($usageList);
         }
@@ -55,7 +55,7 @@ class UsageCommand extends Command
         // the array of arrays you feed it.
         $outputArray = [];
         foreach ($usageList as $key => $value) {
-            array_push($outputArray, ['abstract' => $key, 'locations' => implode("\n", $value)]);
+            $outputArray[] = [ 'abstract' => $key, 'locations' => implode("\n", $value)];
         }
 
         // Build the formatted usage list.

--- a/src/BindingInformation/Services/BindingInformation.php
+++ b/src/BindingInformation/Services/BindingInformation.php
@@ -39,7 +39,7 @@ class BindingInformation
 
         // Use reflection on each of the binding closures to pull the static $concrete and $abstract variables.
         foreach ($bindings as $binding) {
-            $reflection = new ReflectionFunction($binding["concrete"]);
+            $reflection = new ReflectionFunction($binding['concrete']);
 
             $staticVariables = $reflection->getStaticVariables();
 
@@ -47,7 +47,7 @@ class BindingInformation
             // if the boolean is true.
             if (array_has($staticVariables, ['concrete', 'abstract'])
                 && ($includeIlluminate || strpos($staticVariables['abstract'], 'Illuminate\\') === false)) {
-                array_push($foundBindings, array_intersect_key($staticVariables, array_flip(['concrete', 'abstract'])));
+                $foundBindings[] = array_intersect_key($staticVariables, array_flip(['concrete', 'abstract']));
             }
         }
 
@@ -81,10 +81,7 @@ class BindingInformation
                             $bindingsAndLocation[$abstract] = [];
                         }
 
-                        array_push(
-                            $bindingsAndLocation[$abstract],
-                            str_replace(base_path().'\\', '', $file->getPathName())
-                        );
+                        $bindingsAndLocation[$abstract][] = str_replace(base_path().'\\', '', $file->getPathName());
                     }
                 }
             }

--- a/src/ProviderInformation/Commands/ListCommand.php
+++ b/src/ProviderInformation/Commands/ListCommand.php
@@ -13,7 +13,7 @@ class ListCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'provider:list {--sort}';
+    protected $signature = 'provider:list {--include-illuminate} {--sort}';
 
     /**
      * The console command description.
@@ -45,18 +45,13 @@ class ListCommand extends Command
      */
     public function handle(Container $container)
     {
-        $registeredProviders = $this->providerInformation->getRegisteredProviders();
-       
-        $tableRows = [];
-        foreach ($registeredProviders as $provider) {
-            $tableRows[] = ['provider' => get_class($provider)];
-        }
+        $registeredProviders = $this->providerInformation->getProviderList($this->option('include-illuminate'));
 
         if ($this->option('sort')) {
-            asort($tableRows);
+            asort($registeredProviders);
         }
 
-        $headers = ['Providers'];
-        $this->table($headers, $tableRows);
+        $headers = ['Providers', 'Deferred', 'Provides'];
+        $this->table($headers, $registeredProviders);
     }
 }

--- a/src/ProviderInformation/Services/ProviderInformation.php
+++ b/src/ProviderInformation/Services/ProviderInformation.php
@@ -25,15 +25,35 @@ class ProviderInformation
     /**
      * Get the list of registered providers from the Container.
      *
+     * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
+     *
      * @return array containing the registered providers.
      */
-    public function getRegisteredProviders()
+    public function getProviderList($includeIlluminate = true)
     {
         // Use reflection to get the provider array off of the Application
         // The property we're after is 'serviceProviders' on the Application class.
-        $providers = (new ReflectionClass($this->application))->getProperty('serviceProviders');
-        $providers->setAccessible(true);
+        $serviceProviderProperty = (new ReflectionClass($this->application))->getProperty('serviceProviders');
+        $serviceProviderProperty->setAccessible(true);
 
-        return $providers->getValue($this->application);
+        $providers = $serviceProviderProperty->getValue($this->application);
+
+        $foundProviders = [];
+
+        /** @var \Illuminate\Support\ServiceProvider $provider */
+        foreach ($providers as $provider) {
+            $providerClass = get_class($provider);
+
+            // Only include Illuminate bindings if they were specifically requested.
+            if ($includeIlluminate || strpos($providerClass, 'Illuminate\\') === false) {
+                $foundProviders[] = [
+                    'class'    => $providerClass,
+                    'deferred' => $provider->isDeferred() ? 'true' : '',
+                    'provides' => implode("\n", $provider->provides()),
+                ];
+            }
+        }
+
+        return $foundProviders;
     }
 }

--- a/tests/ProviderInformation/Services/ProviderInformationTest.php
+++ b/tests/ProviderInformation/Services/ProviderInformationTest.php
@@ -19,16 +19,37 @@ class ProviderInformationTest extends TestCase
     }
 
     /**
-     * Test the getRegisteredProviders method
+     * Test the getProviderList method
      */
-    public function testGetRegisteredProviders()
+    public function testGetProviderList()
     {
-
         // The service providers are an array of objects stored on the Application
         $providers = [
-            Mockery::mock('One'),
-            Mockery::mock('Two')
+            $providerOne = Mockery::mock('One'),
+            $providerTwo = Mockery::mock('Two')
         ];
+
+        $expected = [
+            [
+                'class' => get_class($providerOne),
+                'deferred' => 'true',
+                'provides' => '',
+            ],
+            [
+                'class' => get_class($providerTwo),
+                'deferred' => '',
+                'provides' => "foo\nbar",
+            ],
+        ];
+
+        $providerOne->shouldReceive('isDeferred')->once()->andReturn(true)
+                    ->shouldReceive('provides')->once()->andReturn([]);
+
+        $providerTwo->shouldReceive('isDeferred')->once()->andReturn(false)
+                    ->shouldReceive('provides')->once()->andReturn([
+                        'foo',
+                        'bar',
+                    ]);
 
         // This is nasty but we're going to override the application controller's service providers using reflection
         // since there's no reliable way to build the expected results.
@@ -40,7 +61,7 @@ class ProviderInformationTest extends TestCase
 
         $service = new ProviderInformation($application);
 
-        $this->assertEquals($service->getRegisteredProviders(), $providers);
+        $this->assertEquals($expected, $service->getProviderList());
 
     }
 


### PR DESCRIPTION
- Renamed getRegisteredProviders to getProviderList for consistency
- Added 'Deferred' and 'Provides' columns to `provider:list` output
- Added `--include-illuminate` flag support to `provider:list`
- Discontinued `array_push` usage in favor of the faster `[]`
- Fixed some sneaky Java-style variable casing