### PR TITLE
Housekeeping Symfony Finder and additional binding usage updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ This is a suite of custom commands for Artisan that gives information about the 
 ## Working with Bindings
 * `binding:list` - Lists the registered bindings by showing the abstract (interface) and concrete class that will be injected.
     * `--include-illuminate` - Indicates that Illuminate classes should be included.  They are not included by default.
-* `binding:usage` - Lists the registered bindings and which files they are referenced in.
+* `binding:usage` - Lists the registered bindings and which files they are referenced in.  By default will exclude `node_modules` and `vendor`.
     * `--include-illuminate` - Indicates that Illuminate classes should be included.  They are not included by default.
+    * `--include-vendor` - Indicates that the vendor directory should be included.  It is not included by default.
+    * `--exclude=` - A comma separated string that indicates which directories to exclude.
     * `--sort` - Indicates that the information should be sorted.
 
 ## Working with Service Providers

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   ],
   "require": {
     "php": ">=7.0.2",
-    "laravel/framework": "~5.0"
+    "laravel/framework": "~5.0",
+    "symfony/finder": "^3.3"
   },
   "autoload": {
     "psr-4": {

--- a/src/BindingInformation/BindingInformationProvider.php
+++ b/src/BindingInformation/BindingInformationProvider.php
@@ -14,7 +14,7 @@ class BindingInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }
@@ -24,7 +24,7 @@ class BindingInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton('command.smcrow.binding.list', function ($app) {
             return $app[ListCommand::class];

--- a/src/BindingInformation/Commands/ListCommand.php
+++ b/src/BindingInformation/Commands/ListCommand.php
@@ -41,9 +41,14 @@ class ListCommand extends Command
      */
     public function handle() : void
     {
-        $foundBindings = $this->bindingInformation->getBindingList($this->option('include-illuminate'));
+        try {
+            $foundBindings = $this->bindingInformation->getBindingList($this->option('include-illuminate'));
 
-        $headers = ['Abstract', 'Concrete'];
-        $this->table($headers, $foundBindings);
+            $headers = ['Abstract', 'Concrete'];
+            $this->table($headers, $foundBindings);
+        } catch (\ReflectionException $e) {
+            $this->error('Problem retrieving the binding list.');
+            $this->error($e->getMessage());
+        }
     }
 }

--- a/src/BindingInformation/Commands/ListCommand.php
+++ b/src/BindingInformation/Commands/ListCommand.php
@@ -39,7 +39,7 @@ class ListCommand extends Command
     /**
      * Execute the console command.
      */
-    public function handle() : void
+    public function handle(): void
     {
         try {
             $foundBindings = $this->bindingInformation->getBindingList($this->option('include-illuminate'));

--- a/src/BindingInformation/Commands/ListCommand.php
+++ b/src/BindingInformation/Commands/ListCommand.php
@@ -3,7 +3,6 @@
 namespace Smcrow\ContainerInformation\BindingInformation\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Container\Container;
 use Smcrow\ContainerInformation\BindingInformation\Services\BindingInformation;
 
 class ListCommand extends Command
@@ -29,7 +28,7 @@ class ListCommand extends Command
 
     /**
      * Create a new command instance.
-     *
+     * @param BindingInformation $bindingInformation
      */
     public function __construct(BindingInformation $bindingInformation)
     {
@@ -39,11 +38,8 @@ class ListCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @param Container $container
-     * @return mixed
      */
-    public function handle(Container $container)
+    public function handle() : void
     {
         $foundBindings = $this->bindingInformation->getBindingList($this->option('include-illuminate'));
 

--- a/src/BindingInformation/Commands/UsageCommand.php
+++ b/src/BindingInformation/Commands/UsageCommand.php
@@ -42,26 +42,31 @@ class UsageCommand extends Command
      */
     public function handle(): void
     {
-        $usageList = $this->bindingInformation
-            ->getUsageList(
-                $this->option('exclude') ?? '',
-                $this->option('include-illuminate'),
-                $this->option('include-vendor')
-            );
+        try {
+            $usageList = $this->bindingInformation
+                ->getUsageList(
+                    $this->option('exclude') ?? '',
+                    $this->option('include-illuminate'),
+                    $this->option('include-vendor')
+                );
 
-        if ($this->option('sort')) {
-            ksort($usageList);
+            if ($this->option('sort')) {
+                ksort($usageList);
+            }
+
+            // There might be a better way to do this using array_map but the table method is pretty picky about
+            // the array of arrays you feed it.
+            $outputArray = [];
+            foreach ($usageList as $key => $value) {
+                $outputArray[] = ['abstract' => $key, 'locations' => implode("\n", $value)];
+            }
+
+            // Build the formatted usage list.
+            $headers = ['Abstract', 'Locations'];
+            $this->table($headers, $outputArray);
+        } catch (\ReflectionException $e) {
+            $this->error('Problem retrieving the usage list.');
+            $this->error($e->getMessage());
         }
-
-        // There might be a better way to do this using array_map but the table method is pretty picky about
-        // the array of arrays you feed it.
-        $outputArray = [];
-        foreach ($usageList as $key => $value) {
-            $outputArray[] = [ 'abstract' => $key, 'locations' => implode("\n", $value)];
-        }
-
-        // Build the formatted usage list.
-        $headers = ['Abstract', 'Locations'];
-        $this->table($headers, $outputArray);
     }
 }

--- a/src/BindingInformation/Commands/UsageCommand.php
+++ b/src/BindingInformation/Commands/UsageCommand.php
@@ -3,7 +3,6 @@
 namespace Smcrow\ContainerInformation\BindingInformation\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Container\Container;
 use Smcrow\ContainerInformation\BindingInformation\Services\BindingInformation;
 
 class UsageCommand extends Command
@@ -13,7 +12,7 @@ class UsageCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'binding:usage {--include-illuminate} {--sort}';
+    protected $signature = 'binding:usage {--include-illuminate} {--include-vendor} {--exclude=} {--sort}';
 
     /**
      * The console command description.
@@ -40,13 +39,16 @@ class UsageCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @param Container $container
-     * @return mixed
      */
-    public function handle(Container $container)
+    public function handle(): void
     {
-        $usageList = $this->bindingInformation->getUsageList($this->option('include-illuminate'));
+        $usageList = $this->bindingInformation
+            ->getUsageList(
+                $this->option('exclude') ?? '',
+                $this->option('include-illuminate'),
+                $this->option('include-vendor')
+            );
+
         if ($this->option('sort')) {
             ksort($usageList);
         }

--- a/src/BindingInformation/Services/BindingInformation.php
+++ b/src/BindingInformation/Services/BindingInformation.php
@@ -3,9 +3,8 @@
 namespace Smcrow\ContainerInformation\BindingInformation\Services;
 
 use Illuminate\Container\Container;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
 use ReflectionFunction;
+use Symfony\Component\Finder\Finder;
 
 /**
  * Service for getting binding information from the Container.
@@ -13,7 +12,6 @@ use ReflectionFunction;
  */
 class BindingInformation
 {
-
     /**
      * @var Container $container
      */
@@ -30,7 +28,7 @@ class BindingInformation
      * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
      * @return array of arrays containing the 'concrete' and 'abstract' classes for each bound pair.
      */
-    public function getBindingList($includeIlluminate = true)
+    public function getBindingList($includeIlluminate = false): array
     {
         // Get the bindings off the injected container.
         $bindings = $this->container->getBindings();
@@ -56,11 +54,17 @@ class BindingInformation
 
     /**
      * Get a list of the bindings and the files in which they are referenced.
+     *
+     * @param string $userExcludedDirectories User provided directories that should be excluded.
      * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
+     * @param bool $includeVendor Whether or not to include the vendor folder.
      * @return array of arrays containing the 'abstract' and an array of files which reference it.
      */
-    public function getUsageList($includeIlluminate = true)
-    {
+    public function getUsageList(
+        string $userExcludedDirectories,
+        $includeIlluminate = false,
+        $includeVendor = false
+    ): array {
         // First get an array of all of the abstracts
         $abstracts = array_column($this->getBindingList($includeIlluminate), 'abstract');
 
@@ -68,25 +72,59 @@ class BindingInformation
         // It's preferable to search each file for each binding rather than for each binding to search each file.
         // This way we are only searching through the file system once.
         $bindingsAndLocation = [];
-        $directory = new RecursiveDirectoryIterator(base_path());
-        foreach (new RecursiveIteratorIterator($directory) as $file) {
-            if ($file->getExtension() === 'php') {
-                $content = file_get_contents($file->getPathname());
-                // search file for each abstract
-                foreach ($abstracts as $abstract) {
-                    if (strpos($content, $abstract) !== false) {
-                        // If we found a reference we will add the file to the array list with the abstract key
-                        if (!array_key_exists($abstract, $bindingsAndLocation)) {
-                            // Initialize the array with the abstract key if it doesn't exist.
-                            $bindingsAndLocation[$abstract] = [];
-                        }
 
-                        $bindingsAndLocation[$abstract][] = str_replace(base_path().'\\', '', $file->getPathName());
+        $finder = app(Finder::class);
+
+        $finder->in(base_path())
+            ->name('*.php')
+            ->exclude($this->getExcludedDirectories($includeVendor, $userExcludedDirectories));
+
+        foreach ($finder as $file) {
+            $content = file_get_contents($file->getPathname());
+            // search file for each abstract
+            foreach ($abstracts as $abstract) {
+                if (strpos($content, $abstract) !== false) {
+                    // If we found a reference we will add the file to the array list with the abstract key
+                    if (!array_key_exists($abstract, $bindingsAndLocation)) {
+                        // Initialize the array with the abstract key if it doesn't exist.
+                        $bindingsAndLocation[$abstract] = [];
                     }
+
+                    $bindingsAndLocation[$abstract][] = str_replace(base_path().'\\', '', $file->getPathName());
                 }
             }
         }
 
         return $bindingsAndLocation;
+    }
+
+    /**
+     * Return an array of directories to exclude in the search.  A user provided directory string will override
+     * all opinionated folders excluding node_modules.
+     *
+     * @param bool $includeVendor Whether vendor should be included.
+     * @param string $userExcludedDirectories A comma separated string of directories to exclude.
+     * @return array
+     */
+    private function getExcludedDirectories(bool $includeVendor, string $userExcludedDirectories): array
+    {
+        // I honestly can't think of a good reason to search in here.
+        $excludedDirectories = ['node_modules'];
+
+        // If the user provided a list of directories, we won't be super opinionated and add our own. Except for
+        // node_modules.
+        if (! empty($userExcludedDirectories)) {
+            return array_unique(array_merge(
+                // Convert user provided commands to an array
+                array_map('trim', explode(',', $userExcludedDirectories)),
+                $excludedDirectories
+            ));
+        }
+
+        if (! $includeVendor) {
+            $excludedDirectories[] = 'vendor';
+        }
+
+        return $excludedDirectories;
     }
 }

--- a/src/BindingInformation/Services/BindingInformation.php
+++ b/src/BindingInformation/Services/BindingInformation.php
@@ -26,7 +26,9 @@ class BindingInformation
      * Get the list of bindings from the Container.
      *
      * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
+     *
      * @return array of arrays containing the 'concrete' and 'abstract' classes for each bound pair.
+     * @throws \ReflectionException
      */
     public function getBindingList($includeIlluminate = false): array
     {
@@ -58,7 +60,9 @@ class BindingInformation
      * @param string $userExcludedDirectories User provided directories that should be excluded.
      * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
      * @param bool $includeVendor Whether or not to include the vendor folder.
+     *
      * @return array of arrays containing the 'abstract' and an array of files which reference it.
+     * @throws \ReflectionException
      */
     public function getUsageList(
         string $userExcludedDirectories,
@@ -104,6 +108,7 @@ class BindingInformation
      *
      * @param bool $includeVendor Whether vendor should be included.
      * @param string $userExcludedDirectories A comma separated string of directories to exclude.
+     *
      * @return array
      */
     private function getExcludedDirectories(bool $includeVendor, string $userExcludedDirectories): array

--- a/src/ContainerInformationProvider.php
+++ b/src/ContainerInformationProvider.php
@@ -14,7 +14,7 @@ class ContainerInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }
@@ -24,7 +24,7 @@ class ContainerInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->register(BindingInformationProvider::class);
         $this->app->register(ProviderInformationProvider::class);

--- a/src/ProviderInformation/Commands/ListCommand.php
+++ b/src/ProviderInformation/Commands/ListCommand.php
@@ -3,7 +3,6 @@
 namespace Smcrow\ContainerInformation\ProviderInformation\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Container\Container;
 use Smcrow\ContainerInformation\ProviderInformation\Services\ProviderInformation;
 
 class ListCommand extends Command
@@ -29,7 +28,7 @@ class ListCommand extends Command
 
     /**
      * Create a new command instance.
-     *
+     * @param ProviderInformation $providerInformation
      */
     public function __construct(ProviderInformation $providerInformation)
     {
@@ -39,19 +38,21 @@ class ListCommand extends Command
 
     /**
      * Execute the console command.
-     *
-     * @param Container $container
-     * @return mixed
      */
-    public function handle(Container $container)
+    public function handle(): void
     {
-        $registeredProviders = $this->providerInformation->getProviderList($this->option('include-illuminate'));
+        try {
+            $registeredProviders = $this->providerInformation->getProviderList($this->option('include-illuminate'));
 
-        if ($this->option('sort')) {
-            asort($registeredProviders);
+            if ($this->option('sort')) {
+                asort($registeredProviders);
+            }
+
+            $headers = ['Providers', 'Deferred', 'Provides'];
+            $this->table($headers, $registeredProviders);
+        } catch (\ReflectionException $e) {
+            $this->error('Problem retrieving the provider list.');
+            $this->error($e->getMessage());
         }
-
-        $headers = ['Providers', 'Deferred', 'Provides'];
-        $this->table($headers, $registeredProviders);
     }
 }

--- a/src/ProviderInformation/ProviderInformationProvider.php
+++ b/src/ProviderInformation/ProviderInformationProvider.php
@@ -13,7 +13,7 @@ class ProviderInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }
@@ -23,7 +23,7 @@ class ProviderInformationProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->app->singleton('command.smcrow.provider.list', function ($app) {
             return $app[ListCommand::class];

--- a/src/ProviderInformation/Services/ProviderInformation.php
+++ b/src/ProviderInformation/Services/ProviderInformation.php
@@ -29,7 +29,7 @@ class ProviderInformation
      *
      * @return array containing the registered providers.
      */
-    public function getProviderList($includeIlluminate = true)
+    public function getProviderList($includeIlluminate = false): array
     {
         // Use reflection to get the provider array off of the Application
         // The property we're after is 'serviceProviders' on the Application class.

--- a/src/ProviderInformation/Services/ProviderInformation.php
+++ b/src/ProviderInformation/Services/ProviderInformation.php
@@ -28,6 +28,7 @@ class ProviderInformation
      * @param bool $includeIlluminate Whether or not to include the Illuminate bindings.
      *
      * @return array containing the registered providers.
+     * @throws \ReflectionException
      */
     public function getProviderList($includeIlluminate = false): array
     {
@@ -40,6 +41,7 @@ class ProviderInformation
 
         $foundProviders = [];
 
+        /** @var array $providers */
         /** @var \Illuminate\Support\ServiceProvider $provider */
         foreach ($providers as $provider) {
             $providerClass = get_class($provider);

--- a/tests/BindingInformation/Services/BindingInformationTest.php
+++ b/tests/BindingInformation/Services/BindingInformationTest.php
@@ -29,40 +29,40 @@ class BindingInformationTest extends TestCase
 
         // If anybody has a decent way of building this array please PR.
         $bindings = [
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Smcrow\TestContracts\Contract1";
-                    static $abstract = "Smcrow\TestImplementations\Implementation1";
+                    static $concrete = 'Smcrow\TestContracts\Contract1';
+                    static $abstract = 'Smcrow\TestImplementations\Implementation1';
                 }
             ],
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Smcrow\TestContracts\Contract2";
-                    static $abstract = "Smcrow\TestImplementations\Implementation2";
+                    static $concrete = 'Smcrow\TestContracts\Contract2';
+                    static $abstract = 'Smcrow\TestImplementations\Implementation2';
                 }
             ],
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Smcrow\TestContracts\Contract3";
-                    static $abstract = "Smcrow\TestImplementations\Implementation3";
+                    static $concrete = 'Smcrow\TestContracts\Contract3';
+                    static $abstract = 'Smcrow\TestImplementations\Implementation3';
                 }
             ],
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Illuminate\TestContracts\Contract1";
-                    static $abstract = "Illuminate\TestImplementations\Implementation1";
+                    static $concrete = 'Illuminate\TestContracts\Contract1';
+                    static $abstract = 'Illuminate\TestImplementations\Implementation1';
                 }
             ],
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Illuminate\TestContracts\Contract2";
-                    static $abstract = "Illuminate\TestImplementations\Implementation2";
+                    static $concrete = 'Illuminate\TestContracts\Contract2';
+                    static $abstract = 'Illuminate\TestImplementations\Implementation2';
                 }
             ],
-            ["concrete" =>
+            ['concrete' =>
                 function () {
-                    static $concrete = "Illuminate\TestContracts\Contract3";
-                    static $abstract = "Illuminate\TestImplementations\Implementation3";
+                    static $concrete = 'Illuminate\TestContracts\Contract3';
+                    static $abstract = 'Illuminate\TestImplementations\Implementation3';
                 }
             ]
         ];
@@ -74,44 +74,44 @@ class BindingInformationTest extends TestCase
         $expectedWithIlluminate =
             [
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract1",
-                    "abstract" => "Smcrow\TestImplementations\Implementation1",
+                    'concrete' => 'Smcrow\TestContracts\Contract1',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation1',
                 ],
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract2",
-                    "abstract" => "Smcrow\TestImplementations\Implementation2",
+                    'concrete' => 'Smcrow\TestContracts\Contract2',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation2',
                 ],
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract3",
-                    "abstract" => "Smcrow\TestImplementations\Implementation3",
+                    'concrete' => 'Smcrow\TestContracts\Contract3',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation3',
                 ],
                 [
-                    "concrete" => "Illuminate\TestContracts\Contract1",
-                    "abstract" => "Illuminate\TestImplementations\Implementation1",
+                    'concrete' => 'Illuminate\TestContracts\Contract1',
+                    'abstract' => 'Illuminate\TestImplementations\Implementation1',
                 ],
                 [
-                    "concrete" => "Illuminate\TestContracts\Contract2",
-                    "abstract" => "Illuminate\TestImplementations\Implementation2",
+                    'concrete' => 'Illuminate\TestContracts\Contract2',
+                    'abstract' => 'Illuminate\TestImplementations\Implementation2',
                 ],
                 [
-                    "concrete" => "Illuminate\TestContracts\Contract3",
-                    "abstract" => "Illuminate\TestImplementations\Implementation3",
+                    'concrete' => 'Illuminate\TestContracts\Contract3',
+                    'abstract' => 'Illuminate\TestImplementations\Implementation3',
                 ]
             ];
 
         $expectedWithoutIlluminate =
             [
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract1",
-                    "abstract" => "Smcrow\TestImplementations\Implementation1",
+                    'concrete' => 'Smcrow\TestContracts\Contract1',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation1',
                 ],
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract2",
-                    "abstract" => "Smcrow\TestImplementations\Implementation2",
+                    'concrete' => 'Smcrow\TestContracts\Contract2',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation2',
                 ],
                 [
-                    "concrete" => "Smcrow\TestContracts\Contract3",
-                    "abstract" => "Smcrow\TestImplementations\Implementation3",
+                    'concrete' => 'Smcrow\TestContracts\Contract3',
+                    'abstract' => 'Smcrow\TestImplementations\Implementation3',
                 ]
             ];
 

--- a/tests/BindingInformation/Services/BindingInformationTest.php
+++ b/tests/BindingInformation/Services/BindingInformationTest.php
@@ -115,8 +115,8 @@ class BindingInformationTest extends TestCase
                 ]
             ];
 
-        $resultsWithIlluminate = $service->getBindingList();
-        $resultsWithoutIlluminate = $service->getBindingList(false);
+        $resultsWithIlluminate = $service->getBindingList(true);
+        $resultsWithoutIlluminate = $service->getBindingList();
 
         $this->assertEquals($resultsWithIlluminate, $expectedWithIlluminate);
         $this->assertEquals($resultsWithoutIlluminate, $expectedWithoutIlluminate);

--- a/tests/ProviderInformation/Services/ProviderInformationTest.php
+++ b/tests/ProviderInformation/Services/ProviderInformationTest.php
@@ -5,13 +5,11 @@ namespace Smcrow\ContainerInformation\ProviderInformation\Tests;
 use Illuminate\Foundation\Application;
 use Mockery;
 use PHPUnit\Framework\TestCase;
-use Smcrow\ContainerInformation\ProviderInformation\Services\ProviderInformation;
 use ReflectionClass;
+use Smcrow\ContainerInformation\ProviderInformation\Services\ProviderInformation;
 
 class ProviderInformationTest extends TestCase
 {
-
-    private $applicationMock;
 
     public function setUp()
     {


### PR DESCRIPTION
In this PR:
- Modified the `binding:usage` command to use Symfony/Finder instead of Recursive iterators as it gives more flexibility.
- Modified the `binding:usage` command to take additional parameters:
     - --include-vendor - indicates that the vendor folder should be included
     - --exclude= - provide a comma separated list of folders to exclude from the search
- The `binding:usage` command now excludes `node_modules` as a hard requirement and `vendor` by default.

- Did some house keeping, found some unnecessary params and return hinting.